### PR TITLE
Update go-datastore to v0.6.0

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -26,7 +26,7 @@ type mongoBatch struct {
 	ds       *MongoDS
 }
 
-func (mb *mongoBatch) Put(key datastore.Key, val []byte) error {
+func (mb *mongoBatch) Put(ctx context.Context, key datastore.Key, val []byte) error {
 	mb.lock.Lock()
 	defer mb.lock.Unlock()
 	if mb.commited {
@@ -38,7 +38,7 @@ func (mb *mongoBatch) Put(key datastore.Key, val []byte) error {
 	return nil
 }
 
-func (mb *mongoBatch) Delete(key datastore.Key) error {
+func (mb *mongoBatch) Delete(ctx context.Context, key datastore.Key) error {
 	mb.lock.Lock()
 	defer mb.lock.Unlock()
 	if mb.commited {
@@ -50,7 +50,7 @@ func (mb *mongoBatch) Delete(key datastore.Key) error {
 	return nil
 }
 
-func (mb *mongoBatch) Commit() error {
+func (mb *mongoBatch) Commit(ctx context.Context) error {
 	mb.lock.Lock()
 	defer mb.lock.Unlock()
 	if mb.commited {
@@ -77,7 +77,7 @@ func (mb *mongoBatch) Commit() error {
 
 	bulkOption := options.BulkWriteOptions{}
 	bulkOption.SetOrdered(false) // Will do things in parallel
-	ctx, cls := context.WithTimeout(context.Background(), mb.ds.opTimeout*time.Duration(len(operations)))
+	ctx, cls := context.WithTimeout(ctx, mb.ds.opTimeout*time.Duration(len(operations)))
 	defer cls()
 	if _, err := mb.ds.col.BulkWrite(ctx, operations, &bulkOption); err != nil {
 		return fmt.Errorf("committing batch: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/textileio/go-ds-mongo
 go 1.14
 
 require (
-	github.com/ipfs/go-datastore v0.4.5
+	github.com/ipfs/go-datastore v0.6.0
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/jbenet/goprocess v0.1.4
 	github.com/stretchr/testify v1.6.1
-	github.com/textileio/go-datastore-extensions v1.0.1
+	github.com/textileio/go-datastore-extensions v1.1.0
 	go.mongodb.org/mongo-driver v1.7.1
+	golang.org/x/sys v0.0.0-20220913175220-63ea55921009 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/textileio/go-datastore-extensions v1.1.0
 	go.mongodb.org/mongo-driver v1.7.1
-	golang.org/x/sys v0.0.0-20220913175220-63ea55921009 // indirect
+	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220913175220-63ea55921009 h1:PuvuRMeLWqsf/ZdT1UUZz0syhioyv1mzuFZsXs4fvhw=
-golang.org/x/sys v0.0.0-20220913175220-63ea55921009/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,11 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/ipfs/go-datastore v0.4.5 h1:cwOUcGMLdLPWgu3SlrCckCMznaGADbPqE0r8h768/Dg=
-github.com/ipfs/go-datastore v0.4.5/go.mod h1:eXTcaaiN6uOlVCLS9GjJUJtlvJfM3xk23w3fyfrmmJs=
+github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
+github.com/ipfs/go-datastore v0.6.0 h1:JKyz+Gvz1QEZw0LsX1IBn+JFCJQH4SJVFtM4uWU0Myk=
+github.com/ipfs/go-datastore v0.6.0/go.mod h1:rt5M3nNbSO/8q1t4LNkLyUwRs8HupMeN/8O4Vn9YAT8=
+github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
+github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-log/v2 v2.3.0 h1:31Re/cPqFHpsRHgyVwjWADPoF0otB1WrjTy8ZFYwEZU=
 github.com/ipfs/go-log/v2 v2.3.0/go.mod h1:QqGoj30OTpnKaG/LKTGTxoP2mmQtjVMEnK72gynbe/g=
@@ -86,8 +89,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/textileio/go-datastore-extensions v1.0.1 h1:qIJGqJaigQ1wD4TdwS/hf73u0HChhXvvUSJuxBEKS+c=
-github.com/textileio/go-datastore-extensions v1.0.1/go.mod h1:Pzj9FDRkb55910dr/FX8M7WywvnS26gBgEDez1ZBuLE=
+github.com/textileio/go-datastore-extensions v1.1.0 h1:rU2oz3iZ50eukiWztXsG3FmSAKwUvIGH1sRv//QXoDs=
+github.com/textileio/go-datastore-extensions v1.1.0/go.mod h1:+LryCa08vOxyo7RwPIshXCqE7TnyV1QyrJ1fQtCipVo=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -135,6 +138,8 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220913175220-63ea55921009 h1:PuvuRMeLWqsf/ZdT1UUZz0syhioyv1mzuFZsXs4fvhw=
+golang.org/x/sys v0.0.0-20220913175220-63ea55921009/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/mongo.go
+++ b/mongo.go
@@ -114,7 +114,7 @@ func (m *MongoDS) GetSize(ctx context.Context, key datastore.Key) (int, error) {
 		return 0, ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
+	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
 	defer cls()
 	return m.getSize(ctx, key)
 }
@@ -125,7 +125,7 @@ func (m *MongoDS) Get(ctx context.Context, key datastore.Key) ([]byte, error) {
 	if m.closed {
 		return nil, ErrClosed
 	}
-	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
+	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
 	defer cls()
 	return m.get(ctx, key)
 }
@@ -137,7 +137,7 @@ func (m *MongoDS) Delete(ctx context.Context, key datastore.Key) error {
 		return ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
+	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
 	defer cls()
 	return m.delete(ctx, key)
 }
@@ -149,7 +149,7 @@ func (m *MongoDS) QueryExtended(ctx context.Context, q dsextensions.QueryExt) (q
 		return nil, ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
+	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
 	defer cls()
 
 	return m.query(ctx, q)
@@ -162,7 +162,7 @@ func (m *MongoDS) Query(ctx context.Context, q query.Query) (query.Results, erro
 		return nil, ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
+	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
 	defer cls()
 
 	qe := dsextensions.QueryExt{Query: q}
@@ -186,12 +186,13 @@ func (m *MongoDS) Close() error {
 }
 
 func (m *MongoDS) get(ctx context.Context, key datastore.Key) ([]byte, error) {
-	sr := m.col.FindOne(ctx, bson.M{"_id": key.String()})
+	id := key.String()
+	sr := m.col.FindOne(ctx, bson.M{"_id": id})
 	if sr.Err() == mongo.ErrNoDocuments {
 		return nil, datastore.ErrNotFound
 	}
 	if sr.Err() != nil {
-		return nil, fmt.Errorf("delete document: %s", sr.Err())
+		return nil, fmt.Errorf("get document: %s", sr.Err())
 	}
 	var kv keyValue
 	if err := sr.Decode(&kv); err != nil {

--- a/mongo.go
+++ b/mongo.go
@@ -71,7 +71,7 @@ func New(ctx context.Context, uri string, dbName string, opts ...Option) (*Mongo
 	}, nil
 }
 
-func (m *MongoDS) Batch() (datastore.Batch, error) {
+func (m *MongoDS) Batch(context.Context) (datastore.Batch, error) {
 	return &mongoBatch{
 		ds:      m,
 		deletes: map[datastore.Key]struct{}{},
@@ -79,7 +79,7 @@ func (m *MongoDS) Batch() (datastore.Batch, error) {
 	}, nil
 }
 
-func (m *MongoDS) Put(key datastore.Key, val []byte) error {
+func (m *MongoDS) Put(ctx context.Context, key datastore.Key, val []byte) error {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.closed {
@@ -91,7 +91,7 @@ func (m *MongoDS) Put(key datastore.Key, val []byte) error {
 	return m.put(ctx, key, val)
 }
 
-func (m *MongoDS) Has(key datastore.Key) (bool, error) {
+func (m *MongoDS) Has(ctx context.Context, key datastore.Key) (bool, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.closed {
@@ -103,66 +103,66 @@ func (m *MongoDS) Has(key datastore.Key) (bool, error) {
 	return m.has(ctx, key)
 }
 
-func (m *MongoDS) Sync(datastore.Key) error {
+func (m *MongoDS) Sync(context.Context, datastore.Key) error {
 	return nil
 }
 
-func (m *MongoDS) GetSize(key datastore.Key) (int, error) {
+func (m *MongoDS) GetSize(ctx context.Context, key datastore.Key) (int, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.closed {
 		return 0, ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
+	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
 	defer cls()
 	return m.getSize(ctx, key)
 }
 
-func (m *MongoDS) Get(key datastore.Key) ([]byte, error) {
+func (m *MongoDS) Get(ctx context.Context, key datastore.Key) ([]byte, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.closed {
 		return nil, ErrClosed
 	}
-	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
+	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
 	defer cls()
 	return m.get(ctx, key)
 }
 
-func (m *MongoDS) Delete(key datastore.Key) error {
+func (m *MongoDS) Delete(ctx context.Context, key datastore.Key) error {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.closed {
 		return ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
+	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
 	defer cls()
 	return m.delete(ctx, key)
 }
 
-func (m *MongoDS) QueryExtended(q dsextensions.QueryExt) (query.Results, error) {
+func (m *MongoDS) QueryExtended(ctx context.Context, q dsextensions.QueryExt) (query.Results, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.closed {
 		return nil, ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
+	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
 	defer cls()
 
 	return m.query(ctx, q)
 }
 
-func (m *MongoDS) Query(q query.Query) (query.Results, error) {
+func (m *MongoDS) Query(ctx context.Context, q query.Query) (query.Results, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	if m.closed {
 		return nil, ErrClosed
 	}
 
-	ctx, cls := context.WithTimeout(context.Background(), m.opTimeout)
+	ctx, cls := context.WithTimeout(ctx, m.opTimeout)
 	defer cls()
 
 	qe := dsextensions.QueryExt{Query: q}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   mongo:
     image: mongo:latest

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -9,5 +9,5 @@ services:
       - -c
       - |
         /usr/bin/mongod --fork --logpath /var/log/mongod.log --bind_ip_all --replSet rs0
-        mongo --eval 'rs.initiate({_id: "rs0", version: 1, members: [{ _id: 0, host: "127.0.0.1:27017" }]})'
+        mongosh --eval 'rs.initiate({_id: "rs0", version: 1, members: [{ _id: 0, host: "127.0.0.1:27017" }]})'
         tail -f /var/log/mongod.log

--- a/test/test.go
+++ b/test/test.go
@@ -67,7 +67,7 @@ func StartMongoDB() (cleanup func()) {
 		log.Fatalf("running docker-compose: %s", err)
 	}
 
-	limit := 10
+	limit := 20
 	retries := 0
 	var err error
 	for retries < limit {

--- a/test/test.go
+++ b/test/test.go
@@ -28,7 +28,8 @@ func StartMongoDB() (cleanup func()) {
 
 	makeDown := func() {
 		cmd := exec.Command(
-			"docker-compose",
+			"docker",
+			"compose",
 			"-f",
 			fmt.Sprintf("%s/docker-compose.yml", dirpath),
 			"down",
@@ -38,13 +39,14 @@ func StartMongoDB() (cleanup func()) {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			log.Fatalf("docker-compose down: %s", err)
+			log.Fatalf("docker compose down: %s", err)
 		}
 	}
 	makeDown()
 
 	cmd := exec.Command(
-		"docker-compose",
+		"docker",
+		"compose",
 		"-f",
 		fmt.Sprintf("%s/docker-compose.yml", dirpath),
 		"build",
@@ -52,10 +54,11 @@ func StartMongoDB() (cleanup func()) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		log.Fatalf("docker-compose build: %s", err)
+		log.Fatalf("docker compose build: %s", err)
 	}
 	cmd = exec.Command(
-		"docker-compose",
+		"docker",
+		"compose",
 		"-f",
 		fmt.Sprintf("%s/docker-compose.yml", dirpath),
 		"up",
@@ -64,7 +67,7 @@ func StartMongoDB() (cleanup func()) {
 	//cmd.Stdout = os.Stdout
 	//cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
-		log.Fatalf("running docker-compose: %s", err)
+		log.Fatalf("running docker compose: %s", err)
 	}
 
 	limit := 20


### PR DESCRIPTION
Add context param where needed to make calls compatible with updated interfaces of ipfs/go-datatastore

Signed-off-by: vkost <viktor.kostadinov@gmail.com>